### PR TITLE
Add `--locked` to the `cargo install` for `wit-abi`.

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ try {
         'install',
         '--git',
         url,
+        '--locked',
         'wit-abi',
         '--tag',
         tag,

--- a/main.js
+++ b/main.js
@@ -36,7 +36,7 @@ try {
     core.info('their `*.wit.md` counterparts. The `wit-abi` tool needs to be');
     core.info('rerun on this branch and the changes should be committed');
     core.info('');
-    core.info(`  cargo install --git ${url} wit-abi --tag ${tag}`);
+    core.info(`  cargo install --git ${url} --locked wit-abi --tag ${tag}`);
     core.info(`  wit-abi .`)
     core.info('');
     core.info('That command will regenerate the `*.abi.md` files to get committed here');


### PR DESCRIPTION
This tells cargo to use wit-abi's checked-in Cargo.lock file, using the
versions of dependencies specified in that file.

This fixes the immediate error in WebAssembly/wasi-tools#2.