### PR TITLE
Update wit-abi-up-to-date to use wit-abi 0.5.0.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   wit-abi-tag:
     description: 'version of the `wit-abi` tool to use'
     required: true
-    default: '0.4.0'
+    default: '0.5.0'
 runs:
   using: 'node12'
   main: 'main.js'


### PR DESCRIPTION
This pulls in https://github.com/WebAssembly/wasi-tools/pull/8, which renames expected to result, removes unit, and handles multiple return values.