### PR TITLE
Update to the latest wasi-tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   wit-abi-tag:
     description: 'version of the `wit-abi` tool to use'
     required: true
-    default: '0.7.0'
+    default: '0.9.0'
 runs:
   using: 'node16'
   main: 'main.js'

--- a/main.js
+++ b/main.js
@@ -27,7 +27,9 @@ try {
     core.startGroup('Use `wit-abi` to verify abi files are up to date');
     child_process.execFileSync(
       'wit-abi',
-      ['markdown', '--check', '--world=world', 'wit'],
+      // Use '--html-in-md' since at present the generated HTML is nicer than
+      // the generated markdown.
+      ['markdown', '--check', '--html-in-md', 'wit'],
       { stdio: [null, process.stdout, process.stdout] },
     );
     core.endGroup();


### PR DESCRIPTION
 - Drop --world=world, which is no longer needed.

 - Add --html-in-md, since the genrated HTML is a little nicer than the raw markdown at present.