### PR TITLE
Require semicolons in WIT files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ runs:
       shell: bash
       if: ${{ inputs.worlds == '*' }}
       run: wit-bindgen markdown wit --check --html-in-md
+      env:
+        WIT_REQUIRE_SEMICOLONS: 1
 
     - name: Generate documentation for each world
       shell: bash


### PR DESCRIPTION
This is a step further in the plan to add semicolons to WIT files everywhere. Now that tooling should have support for semicolons this updates the github action here to, by default, require semicolons. That way when proposals update to a new version of this action they'll by default require semicolons as well.