### PR TITLE
Remove out of date references to `*.wit.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Action for `*.wit.md` files
+# GitHub Action for generating `*.md` from `*.wit`.
 
 Configured with:
 

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: bash
       run: |
         echo 'Failed to verity that `*.md` files are up-to-date with'
-        echo 'their `wit/*.wit.md` counterparts. The `wit-bindgen` tool needs to'
+        echo 'their `wit/*.wit` counterparts. The `wit-bindgen` tool needs to'
         echo 'be rerun on this branch and the changes should be committed'
         echo ''
         echo '  cargo install wit-bindgen-cli@{{ inputs.wit-bindgen }}'


### PR DESCRIPTION
`.wit.md` files are no longer used in the WASI repos, so update the documentation to just talk about `.wit` files.