### PR TITLE
Make the version of `wasm-tools` user-configurable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   wit-bindgen:
     description: 'version of the `wit-bindgen` tool to use'
     required: false
-    default: '0.26.0'
+    default: '0.30.0'
   worlds:
     description: 'worlds to generate documentation for'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'Verify WASI ABI files are up-to-date'
 description: 'Verify WASI ABI files are up-to-date'
 
 inputs:
+  wasm-tools:
+    description: 'version of `wasm-tools` to use'
+    required: false
+    default: '1.215.0'
   wit-bindgen:
     description: 'version of the `wit-bindgen` tool to use'
     required: false
@@ -29,7 +33,7 @@ runs:
     - name: Setup `wasm-tools`
       uses: bytecodealliance/actions/wasm-tools/setup@v1.1.0
       with:
-        version: 1.209.1
+        version: ${{ inputs.wasm-tools }}
 
     - name: Generate documentation for each world
       shell: bash


### PR DESCRIPTION
Right now the version of `wasm-tools` is hard-coded to a version May. This makes the version of `wasm-tools` user-configurable, so users of the action can update it when they need to.

This would fix CI issues like the one in https://github.com/WebAssembly/wasi-http/pull/127 where we're using new WIT features that are newly supported by the parser. Thanks!