### PR TITLE
chore: update default wasm-tools, bindgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: WebAssembly/wit-abi-up-to-date@v20
+    - uses: WebAssembly/wit-abi-up-to-date@v23
 ```
 
 optionally:
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: WebAssembly/wit-abi-up-to-date@v20
+    - uses: WebAssembly/wit-abi-up-to-date@v23
       with:
-        wit-bindgen: '0.26.0'
+        wit-bindgen: '0.42.1'
         worlds: 'command reactor'
         directory: 'wit'
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,11 @@ inputs:
   wasm-tools:
     description: 'version of `wasm-tools` to use'
     required: false
-    default: '1.215.0'
+    default: 'v1.233.0'
   wit-bindgen:
     description: 'version of the `wit-bindgen` tool to use'
     required: false
-    default: '0.30.0'
+    default: '0.42.1'
   worlds:
     description: 'worlds to generate documentation for'
     required: false


### PR DESCRIPTION
Fixes Error: failed to find release for tag 'wasm-tools-1.215.0' for platform 'linux' and arch 'x86_64'
